### PR TITLE
added extra param for passing extra info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .buildpath
 .flexProperties

--- a/jquery/jRating.jquery.js
+++ b/jquery/jRating.jquery.js
@@ -60,6 +60,7 @@
 
 			var average = parseFloat($(this).attr('data-average')), // get the average of all rates
 			idBox = parseInt($(this).attr('data-id')), // get the id of the box
+            extraParam = $(this).attr('data-extra'), // get the extra param
 			widthRatingContainer = starWidth*opts.length, // Width of the Container
 			widthColor = average/opts.rateMax*widthRatingContainer, // Width of the color Container
 
@@ -164,7 +165,8 @@
 						$.post(opts.phpPath,{
 								idBox : idBox,
 								rate : rate,
-								action : 'rating'
+								action : 'rating',
+                                extra: extraParam
 							},
 							function(data) {
 								if(!data.error)


### PR DESCRIPTION
Added support for an extra parameter. Lets say you have different content type like videos, pictures, blog posts and you implement the script using only one action to save data to DB. Each content type has it's own table. To differentiate the request you just add 'data-extra="[type-value]" to html, and the script sends it to backend processing script. In the backend you do your stuff depending on extra param if nedded.